### PR TITLE
Enrico's video + Minor Jekyll fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# Jekyll powered website for [Sydney CocoaHeads](http://www.sydneycocoaheads.com)
+
+## Local development quickstart
+
+After checking out the repository:
+
+```
+git submodule init
+git submodule update
+gem install jekyll
+jekyll serve --watch --future
+```

--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ title: Sydney CocoaHeads
 email: mark@aufflick.com
 description: The iOS & Mac developer meetup in Sydney, Australia
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://SydneyCocoaHeads.github.io" # the base hostname & protocol for your site
+url: "http://www.sydneycocoaheads.com" # the base hostname & protocol for your site
 twitter_username: CocoaHeadsAU
 github_username:  SydneyCocoaHeads
 permalink: /:year/:month/:day/:title/
@@ -20,3 +20,4 @@ timezone: Etc/UTC
 
 # Build settings
 markdown: kramdown
+exclude: [README.md]

--- a/_includes/scale.fix.js.html
+++ b/_includes/scale.fix.js.html
@@ -1,3 +1,4 @@
+<script>
 var metas = document.getElementsByTagName('meta');
 var i;
 if (navigator.userAgent.match(/iPhone/i)) {
@@ -15,3 +16,4 @@ function gestureStart() {
     }
   }
 }
+</script>

--- a/_layouts/by_category.html
+++ b/_layouts/by_category.html
@@ -8,7 +8,7 @@ layout: default
         {% for post in site.categories[page.category] %}
         <li>
           <span class="post-meta">{{ post.date | date: "%b %-d, %Y" }}</span>
-          <p><a href="{{ post.url }}/">{{ post.title }}</a></p>
+          <p><a href="{{ post.url }}">{{ post.title }}</a></p>
         </li>
         {% endfor %}
     {% else %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,6 +14,7 @@
     {% include footer.html %}
 
    </div>
-  <script src="javascripts/scale.fix.js"></script>
+
+   {% include scale.fix.js.html %}
  </body>
 </html>

--- a/_posts/2016-05-21-video-fastlane-ci-automation-by-enrico-susatyo.markdown
+++ b/_posts/2016-05-21-video-fastlane-ci-automation-by-enrico-susatyo.markdown
@@ -1,0 +1,14 @@
+---
+author: karlbowden
+date: 2016-05-22 09:48:00+00:00
+layout: post
+slug: fastlane-ci-automation-by-enrico-susatyo
+title: Fastlane CI Automation by Enrico Susatyo
+categories:
+- Presentations
+- video
+---
+
+At the April meetup of Sydney CocoaHeads, Enrico Susatyo gave a great talk on using Twitter / Fabric fastlane to automate builds, test flight uploads, and other CI goodness for streamlining your iOS projects.
+
+<div class="aspect-block aspect-block--16-by-9"><iframe src="https://player.vimeo.com/video/167115233?title=0&byline=0&portrait=0&color=ffffff" width="500" height="281" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe></div>

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -194,7 +194,35 @@ footer {
   -webkit-font-smoothing:subpixel-antialiased;
 }
 
-@media print, screen and (max-width: 960px) {
+.center-image {
+  margin: 0 auto;
+  display: block;
+}
+
+.aspect-block {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 0;
+  margin: 1em 0;
+  padding: 0;
+}
+
+.aspect-block--16-by-9 {
+  padding-top: 56.25%;
+}
+
+.aspect-block > * {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+}
+
+@media print, screen and (max-width: 960px), screen and (max-height: 760px) {
 
   div.wrapper {
     width:auto;
@@ -229,7 +257,7 @@ footer {
   }
 }
 
-@media print, screen and (max-width: 720px) {
+@media print, screen and (max-width: 720px), screen and (max-height: 760px) {
   body {
     word-wrap:break-word;
   }
@@ -267,10 +295,4 @@ footer {
     font-size:12pt;
     color:#444;
   }
-}
-
-.center-image
-{
-    margin: 0 auto;
-    display: block;
 }


### PR DESCRIPTION
# Jekyll
- Update the website url in config
- scale.fix.js was not loading when viewing any page other than root. The script was tiny, so moved it to an inclusion
- Remove the double slash on links in the category pages
- Add a basic readme file to start building from
- Add styles to support resizing video while maintaing aspect
- Fallback to static header and footer positioning for reduced screen height to prevent overlapping and unusable sidebar content
# Publish
- Video: Fastlane CI Automation by Enrico Sustyo
