### PR TITLE
Add automatic Meetup event details to the home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,12 +6,97 @@ layout: default
 
   <h1 class="page-heading">Next Meetup</h1>
 
-  <a class="embedly-card" data-card-key="547e892ffb4b4b2084f3c0428496a2e7" data-card-chrome="0" data-card-controls="0" data-card-align="left" href="http://www.meetup.com/sydneycocoaheads/events/233283373/">Sydney CocoaHeads Meetup Details</a>
-  <script async src="//cdn.embedly.com/widgets/platform.js" charset="UTF-8"></script>
 
-  <p></p>
+  <div class="meetup__loading">Loading event details...</div>
+  <div class="meetup__widget-failed" style="display: none;">
+      <a class="meetup__link-failed" href="">Check out Sydney Cocoaheads on Meetup →</a>
+  </div>
+  <div class="meetup__widget" style="display: none;">
+    <div class="meetup__branding">
+      <img class="meetup__favicon" src="http://www.meetup.com/favicon.ico" width="16" height="16">
+      <a class="meetup__branding-link" href="http://www.meetup.com/">Meetup</a>
+    </div>
+    <h2 class="meetup__title"></h2>
+    <p class="meetup__date"></p>
+    <div class="meetup__attendance">
+      <p class="meetup__going-count"></p>
+    </div>
+    <p class="meetup__venue">
+      <span class="meetup__venue-name"></span><br>
+      <span class="meetup__venue-address"></span>
+    </p>
+    <div class="meetup__description"></div>
+    <a class="meetup__link" href="">Check out this Meetup →</a>
+  </div>
 
-  
+  <script src="https://code.jquery.com/jquery-3.1.0.min.js"></script>
+  <script>
+    $(function($) {
+      var eventsUrl = "https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_urlname=sydneycocoaheads&photo-host=public&page=1&fields=&order=time&status=upcoming%2Cpast&desc=true&sig_id=95063442&sig=dfa3d8a5909deee61d1817facb5ee3ebd00d110d"
+      $.ajax(eventsUrl, {
+        crossDomain: true,
+        jsonp: 'callback',
+        dataType: 'jsonp',
+        success: onResponseSuccess,
+        failure: onResponseError
+      });
+
+      function onResponseError() {
+        $('.meetup__loading').hide();
+        $('.meetup__widget-failed').show();
+      }
+
+      function onResponseSuccess(response) {
+        if (response.results && response.results.length > 0) {
+          return updateWidget(response.results[0]);
+        }
+        onResponseError();
+      }
+
+      function updateWidget(event) {
+        console.log(event);
+        $('.meetup__title').text(event.name);
+        $('.meetup__date').text(formatDate(new Date(event.time)));
+        $('.meetup__venue-name').text(event.venue.name); // Atlassian
+        $('.meetup__venue-address').text([
+            event.venue.address_1,
+            event.venue.city,
+            event.venue.country,
+          ].join(' ')); // Level 6  341 George St sydney, AU
+        $('.meetup__going-count').text(goingText(event));
+        $('.meetup__description').html(event.description);
+        $('.meetup__link').attr('href', event.event_url); // Level 6  341 George St sydney, AU
+        $('.meetup__loading').hide();
+        $('.meetup__widget').show();
+      }
+
+      function formatDate(date) {
+        var monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+        var dayNames = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
+        var dayOfWeek = date.getDay();
+        var dayOfMonth = date.getDate();
+        var month = date.getMonth();
+        var year = date.getFullYear();
+        var hours = date.getHours();
+        var minutes = date.getMinutes();
+        var hours12 = hours % 12;
+        var ampm = hours == hours12 ? 'AM' : 'PM';
+        return (dayNames[dayOfWeek] + ', ' +
+          monthNames[month] + ' ' + dayOfMonth + ', ' +
+          year + ', ' +
+          hours12 + ':' + minutes + ' ' + ampm);
+      }
+
+      function goingText(event) {
+        if (event.status == 'past') {
+          return event.yes_rsvp_count + ' People Went';
+        } else {
+          return event.yes_rsvp_count + ' People Attending';
+        }
+      }
+    });
+  </script>
+
   {% assign post = site.posts[0] %}
   <h1 class="post-title" itemprop="name headline">{{ post.title }}</h1>
   <p class="post-meta"><time datetime="{{ post.date | date_to_xmlschema }}" itemprop="datePublished">{{ post.date | date: "%b %-d, %Y" }}</time>{% if post.author %} • <span itemprop="author" itemscope itemtype="http://schema.org/Person"><span itemprop="name">{{ post.author }}</span></span>{% endif %}</p>

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -222,6 +222,87 @@ footer {
   height: 100%;
 }
 
+/* -- Meetup widget -- */
+
+.meetup__loading,
+.meetup__widget-failed {
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  padding: 20px 15px;
+  background: #eee;
+  font-size: 16px;
+  text-align: center;
+  color: #000;
+  margin-bottom: 3em;
+}
+
+.meetup__widget {
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  padding: 20px 15px;
+  background: #eee;
+  margin-bottom: 3em;
+}
+
+.meetup__branding {
+  float: right;
+}
+.meetup__favicon {
+  display: inline-block;
+  vertical-align: middle;
+}
+.meetup__branding-link {
+  color: #a7241d;
+}
+
+.meetup__going-count {
+  color: #33a71d;
+}
+
+.meetup__date {
+  font-weight: bold;
+  color: #393939;
+}
+
+.meetup__venue {
+  color: #393939;
+}
+
+.meetup__description {
+  margin: 0 -15px;
+  padding: 20px 15px;
+  border-top: 1px solid #ddd;
+  border-bottom: 1px solid #ddd;
+  background: #fff;
+}
+
+.meetup__description p {
+  margin-bottom: 5px;
+}
+
+.meetup__link-failed,
+.meetup__link {
+  background: #a7241d;
+  border-radius: 3px;
+  color: #fff;
+  cursor: pointer;
+  display: block;
+  font-size: 1rem;
+  font-weight: 600;
+  padding: 0.5em 1em;
+  text-align: center;
+}
+.meetup__link-failed:hover, .meetup__link-failed:focus,
+.meetup__link:hover, .meetup__link:focus {
+  background: #ed1c40;
+  color: #fff;
+}
+.meetup__link {
+  margin: 1em 0 0;
+}
+
+
+
 @media print, screen and (max-width: 960px), screen and (max-height: 760px) {
 
   div.wrapper {


### PR DESCRIPTION
Fetch details of the latest past or upcoming event from Meetup and display it on the home page.
It uses a signed Meetup API request and falls back to a link to Meetup if loading the event details fail.

It is sensitive to malformed html passed in from Meetup, but as long as the event details can be edited, it should be fine.

It looks like:

![screencapture-localhost-4000-1473605435280](https://cloud.githubusercontent.com/assets/117041/18418120/fd085cf0-7883-11e6-9d25-c6a958aa9295.jpg)
